### PR TITLE
feat: CodeRabbitの日本語レビュー設定を追加

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit設定ファイル - 日本語でのレビューを有効化
+language: "ja-JP"
+early_access: false
+enable_free_tier: true
+tone_instructions: ''
+knowledge_base:
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+chat:
+  auto_reply: true
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: false
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  # 日本語でのレビューに関する追加設定
+  review_language: "Japanese"
+  review_instructions: |
+    - レビューは日本語で行ってください
+    - 専門用語は適切に日本語化してください
+    - コードのコメントは英語のままで構いません

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,10 @@
 language: "ja-JP"
 early_access: false
 enable_free_tier: true
-tone_instructions: ''
+tone_instructions: |
+  - レビューは日本語で行ってください
+  - 専門用語は適切に日本語化してください
+  - コードのコメントは英語のままで構いません
 knowledge_base:
   learnings:
     scope: auto
@@ -18,9 +21,3 @@ reviews:
   poem: false
   review_status: true
   collapse_walkthrough: true
-  # 日本語でのレビューに関する追加設定
-  review_language: "Japanese"
-  review_instructions: |
-    - レビューは日本語で行ってください
-    - 専門用語は適切に日本語化してください
-    - コードのコメントは英語のままで構いません


### PR DESCRIPTION
- .coderabbit.yamlファイルを作成
- language: "ja-JP"を設定し、日本語でのPRレビューを有効化
- 無料プランでの利用を維持（enable_free_tier: true）
- レビュープロファイルをchillに設定し、過度に厳格でないレビューを実現

🤖 Generated with [Claude Code](https://claude.ai/code)