### PR TITLE
feat: GitHub bot comment Slack notifications

### DIFF
--- a/.github/workflows/bot-comment-notify-advanced.yml
+++ b/.github/workflows/bot-comment-notify-advanced.yml
@@ -1,0 +1,304 @@
+name: Advanced Bot Comment Notification
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+env:
+  # フィルタリング設定（環境変数で管理）
+  NOTIFY_KEYWORDS: "review,approved,changes requested,vulnerability,error,warning,bug,security"
+  IGNORE_KEYWORDS: "WIP,draft,test"
+  NOTIFY_CODERABBIT: "true"
+  NOTIFY_CLAUDE: "true"
+  NOTIFY_OTHER_BOTS: "false"
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if should notify
+        id: should-notify
+        run: |
+          # デフォルトは通知しない
+          echo "should_notify=false" >> $GITHUB_OUTPUT
+
+          # ボットかどうかチェック
+          USER_LOGIN="${{ github.event.comment.user.login }}"
+          IS_BOT=false
+          BOT_TYPE=""
+
+          # CodeRabbitチェック
+          if [[ "$USER_LOGIN" =~ coderabbit ]]; then
+            IS_BOT=true
+            BOT_TYPE="coderabbit"
+            if [[ "${{ env.NOTIFY_CODERABBIT }}" == "true" ]]; then
+              echo "should_notify=true" >> $GITHUB_OUTPUT
+            fi
+          # GitHub Actions bot（Claude Code Action含む）チェック
+          elif [[ "$USER_LOGIN" == "github-actions[bot]" ]]; then
+            IS_BOT=true
+            # Claude Code Actionかどうかをコメント内容から判定
+            COMMENT_BODY="${{ github.event.comment.body }}"
+            if echo "$COMMENT_BODY" | grep -qiE "(Claude|Anthropic|claude-code-action|Claude Code)"; then
+              BOT_TYPE="claude"
+              if [[ "${{ env.NOTIFY_CLAUDE }}" == "true" ]]; then
+                echo "should_notify=true" >> $GITHUB_OUTPUT
+              fi
+            else
+              BOT_TYPE="other"
+              if [[ "${{ env.NOTIFY_OTHER_BOTS }}" == "true" ]]; then
+                echo "should_notify=true" >> $GITHUB_OUTPUT
+              fi
+            fi
+          fi
+
+          echo "is_bot=$IS_BOT" >> $GITHUB_OUTPUT
+          echo "bot_type=$BOT_TYPE" >> $GITHUB_OUTPUT
+
+          # ボットでない場合は処理終了
+          if [[ "$IS_BOT" != "true" ]]; then
+            exit 0
+          fi
+
+          # キーワードフィルタリング
+          COMMENT_BODY="${{ github.event.comment.body }}"
+
+          # 無視キーワードチェック
+          if [[ -n "${{ env.IGNORE_KEYWORDS }}" ]]; then
+            IFS=',' read -ra IGNORE_ARRAY <<< "${{ env.IGNORE_KEYWORDS }}"
+            for keyword in "${IGNORE_ARRAY[@]}"; do
+              if echo "$COMMENT_BODY" | grep -qi "$keyword"; then
+                echo "should_notify=false" >> $GITHUB_OUTPUT
+                echo "Ignored due to keyword: $keyword"
+                exit 0
+              fi
+            done
+          fi
+
+          # 通知キーワードチェック（指定されている場合）
+          if [[ -n "${{ env.NOTIFY_KEYWORDS }}" ]]; then
+            FOUND_KEYWORD=false
+            IFS=',' read -ra NOTIFY_ARRAY <<< "${{ env.NOTIFY_KEYWORDS }}"
+            for keyword in "${NOTIFY_ARRAY[@]}"; do
+              if echo "$COMMENT_BODY" | grep -qi "$keyword"; then
+                FOUND_KEYWORD=true
+                echo "matched_keyword=$keyword" >> $GITHUB_OUTPUT
+                break
+              fi
+            done
+
+            # キーワードが見つからなかった場合は通知しない
+            if [[ "$FOUND_KEYWORD" != "true" ]]; then
+              echo "should_notify=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - name: Set bot info
+        if: steps.should-notify.outputs.should_notify == 'true'
+        id: bot-info
+        run: |
+          BOT_TYPE="${{ steps.should-notify.outputs.bot_type }}"
+
+          case "$BOT_TYPE" in
+            "coderabbit")
+              echo "bot_name=CodeRabbit" >> $GITHUB_OUTPUT
+              echo "bot_icon=🐰" >> $GITHUB_OUTPUT
+              echo "bot_color=#FF6B6B" >> $GITHUB_OUTPUT
+              ;;
+            "claude")
+              echo "bot_name=Claude Code Action" >> $GITHUB_OUTPUT
+              echo "bot_icon=🤖" >> $GITHUB_OUTPUT
+              echo "bot_color=#6366F1" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "bot_name=GitHub Actions Bot" >> $GITHUB_OUTPUT
+              echo "bot_icon=⚙️" >> $GITHUB_OUTPUT
+              echo "bot_color=#808080" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Analyze comment content
+        if: steps.should-notify.outputs.should_notify == 'true'
+        id: comment-analysis
+        run: |
+          COMMENT_BODY="${{ github.event.comment.body }}"
+
+          # コメントの重要度を判定
+          IMPORTANCE="normal"
+          if echo "$COMMENT_BODY" | grep -qiE "(error|failed|failure|bug|vulnerability|security)"; then
+            IMPORTANCE="high"
+          elif echo "$COMMENT_BODY" | grep -qiE "(approved|lgtm|success|passed)"; then
+            IMPORTANCE="success"
+          elif echo "$COMMENT_BODY" | grep -qiE "(warning|suggestion|consider)"; then
+            IMPORTANCE="warning"
+          fi
+
+          echo "importance=$IMPORTANCE" >> $GITHUB_OUTPUT
+
+          # 重要度に応じた絵文字とメンション設定
+          case "$IMPORTANCE" in
+            "high")
+              echo "importance_icon=🚨" >> $GITHUB_OUTPUT
+              echo "mention=<!channel>" >> $GITHUB_OUTPUT
+              ;;
+            "success")
+              echo "importance_icon=✅" >> $GITHUB_OUTPUT
+              echo "mention=" >> $GITHUB_OUTPUT
+              ;;
+            "warning")
+              echo "importance_icon=⚠️" >> $GITHUB_OUTPUT
+              echo "mention=" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "importance_icon=📝" >> $GITHUB_OUTPUT
+              echo "mention=" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+          # コメントプレビュー作成
+          PREVIEW=$(echo "$COMMENT_BODY" | tr '\n' ' ' | cut -c1-500)
+          if [ ${#COMMENT_BODY} -gt 500 ]; then
+            PREVIEW="${PREVIEW}..."
+          fi
+          echo "preview<<EOF" >> $GITHUB_OUTPUT
+          echo "$PREVIEW" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Set Slack channel
+        if: steps.should-notify.outputs.should_notify == 'true'
+        id: slack-channel
+        run: |
+          # ブランチやラベルに基づいてチャンネルを決定
+          # デフォルトチャンネル
+          CHANNEL="#github-notifications"
+
+          # mainブランチへのPRの場合
+          if [[ "${{ github.event.issue.pull_request }}" != "" ]] && [[ "${{ github.base_ref }}" == "main" ]]; then
+            CHANNEL="#production-alerts"
+          fi
+
+          # 特定のラベルがある場合
+          if [[ "${{ contains(github.event.issue.labels.*.name, 'urgent') }}" == "true" ]]; then
+            CHANNEL="#urgent-notifications"
+          elif [[ "${{ contains(github.event.issue.labels.*.name, 'security') }}" == "true" ]]; then
+            CHANNEL="#security-alerts"
+          fi
+
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+
+      - name: Send Slack notification
+        if: steps.should-notify.outputs.should_notify == 'true'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # channel-idパラメータでチャンネルを指定可能（オプション）
+          # channel-id: ${{ steps.slack-channel.outputs.channel }}
+          payload: |
+            {
+              "text": "${{ steps.comment-analysis.outputs.importance_icon }} ${{ steps.bot-info.outputs.bot_icon }} ${{ steps.bot-info.outputs.bot_name }} commented on ${{ github.event.issue.pull_request && 'PR' || 'Issue' }} #${{ github.event.issue.number }} ${{ steps.comment-analysis.outputs.mention }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ steps.comment-analysis.outputs.importance_icon }} ${{ steps.bot-info.outputs.bot_icon }} ${{ steps.bot-info.outputs.bot_name }} がコメントしました* ${{ steps.comment-analysis.outputs.mention }}"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "重要度: ${{ steps.comment-analysis.outputs.importance }} | キーワード: ${{ steps.should-notify.outputs.matched_keyword || 'なし' }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*リポジトリ:*\n`${{ github.repository }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*${{ github.event.issue.pull_request && 'プルリクエスト' || 'イシュー' }}:*\n<${{ github.event.issue.html_url }}|#${{ github.event.issue.number }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*タイトル:*\n${{ github.event.issue.title }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*作成者:*\n${{ github.event.issue.user.login }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*ボット:*\n`${{ github.event.comment.user.login }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*日時:*\n<!date^${{ github.event.comment.created_at }}^{date_short_pretty} {time}|${{ github.event.comment.created_at }}>"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*コメント内容:*\n```${{ steps.comment-analysis.outputs.preview }}```"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "コメントを見る 👀",
+                        "emoji": true
+                      },
+                      "url": "${{ github.event.comment.html_url }}",
+                      "style": "primary"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "${{ github.event.issue.pull_request && 'PR' || 'Issue' }}を開く 📄",
+                        "emoji": true
+                      },
+                      "url": "${{ github.event.issue.html_url }}"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "リポジトリ 📁",
+                        "emoji": true
+                      },
+                      "url": "${{ github.event.repository.html_url }}"
+                    }
+                  ]
+                }
+              ],
+              "attachments": [
+                {
+                  "color": "${{ steps.bot-info.outputs.bot_color }}",
+                  "footer": "GitHub Bot Comment Notifier | ${{ steps.slack-channel.outputs.channel }}",
+                  "footer_icon": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                  "ts": "${{ github.event.comment.created_at }}"
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/bot-comment-notify.yml
+++ b/.github/workflows/bot-comment-notify.yml
@@ -1,0 +1,148 @@
+name: Bot Comment Notification
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    # PRまたはIssueへのコメントで、CodeRabbitまたはGitHub Actionsボットからのコメントのみを対象とする
+    if: |
+      (github.event.issue.pull_request || github.event.issue) &&
+      (contains(github.event.comment.user.login, 'coderabbit') ||
+       github.event.comment.user.login == 'github-actions[bot]')
+
+    steps:
+      - name: Determine bot type
+        id: bot-type
+        run: |
+          # ボットのタイプを判定
+          if [[ "${{ github.event.comment.user.login }}" == "github-actions[bot]" ]]; then
+            # コメント内容からClaude Code Actionかどうかを判定
+            if echo "${{ github.event.comment.body }}" | grep -qiE "(Claude|Anthropic|claude-code-action)"; then
+              echo "bot_name=Claude Code Action" >> $GITHUB_OUTPUT
+              echo "bot_icon=🤖" >> $GITHUB_OUTPUT
+              echo "bot_color=#6366F1" >> $GITHUB_OUTPUT
+            else
+              echo "bot_name=GitHub Actions Bot" >> $GITHUB_OUTPUT
+              echo "bot_icon=⚙️" >> $GITHUB_OUTPUT
+              echo "bot_color=#808080" >> $GITHUB_OUTPUT
+            fi
+          elif [[ "${{ github.event.comment.user.login }}" =~ "coderabbit" ]]; then
+            echo "bot_name=CodeRabbit" >> $GITHUB_OUTPUT
+            echo "bot_icon=🐰" >> $GITHUB_OUTPUT
+            echo "bot_color=#FF6B6B" >> $GITHUB_OUTPUT
+          else
+            echo "bot_name=Unknown Bot" >> $GITHUB_OUTPUT
+            echo "bot_icon=🤷" >> $GITHUB_OUTPUT
+            echo "bot_color=#808080" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Extract comment preview
+        id: comment-preview
+        run: |
+          # コメントの最初の500文字を抽出（Slack表示用）
+          COMMENT_BODY="${{ github.event.comment.body }}"
+          # 改行を \n に変換し、500文字に制限
+          PREVIEW=$(echo "$COMMENT_BODY" | tr '\n' ' ' | cut -c1-500)
+          if [ ${#COMMENT_BODY} -gt 500 ]; then
+            PREVIEW="${PREVIEW}..."
+          fi
+          # GitHub Outputに安全に出力するためにエスケープ
+          echo "preview<<EOF" >> $GITHUB_OUTPUT
+          echo "$PREVIEW" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "${{ steps.bot-type.outputs.bot_icon }} ${{ steps.bot-type.outputs.bot_name }} commented on ${{ github.event.issue.pull_request && 'PR' || 'Issue' }} #${{ github.event.issue.number }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ steps.bot-type.outputs.bot_icon }} ${{ steps.bot-type.outputs.bot_name }} がコメントしました*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*リポジトリ:*\n${{ github.repository }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*${{ github.event.issue.pull_request && 'プルリクエスト' || 'イシュー' }}:*\n<${{ github.event.issue.html_url }}|#${{ github.event.issue.number }} ${{ github.event.issue.title }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*ボット:*\n`${{ github.event.comment.user.login }}`"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*作成日時:*\n${{ github.event.comment.created_at }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*コメント内容:*\n```${{ steps.comment-preview.outputs.preview }}```"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "コメントを見る",
+                        "emoji": true
+                      },
+                      "url": "${{ github.event.comment.html_url }}",
+                      "style": "primary"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "${{ github.event.issue.pull_request && 'PR' || 'Issue' }}を開く",
+                        "emoji": true
+                      },
+                      "url": "${{ github.event.issue.html_url }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "${{ github.event.repository.full_name }} • ${{ github.event.comment.author_association }}"
+                    }
+                  ]
+                }
+              ],
+              "attachments": [
+                {
+                  "color": "${{ steps.bot-type.outputs.bot_color }}",
+                  "footer": "GitHub Actions Bot Comment Notifier",
+                  "footer_icon": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                  "ts": "${{ github.event.comment.created_at }}"
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 │   ├── init-firewall.sh      # セキュリティのためのファイアウォール設定
 │   ├── install-extensions.sh # VSCodeフォーク拡張機能インストールスクリプト
 │   └── extensions/           # VSCodeフォーク拡張機能のVSIXファイル格納ディレクトリ
+├── .github/workflows/        # GitHub Actionsワークフロー
+│   ├── bot-comment-notify.yml # ボットコメント通知（基本版）
+│   ├── bot-comment-notify-advanced.yml # ボットコメント通知（高度版）
+│   ├── extension-test.yml    # VSCodeフォーク拡張機能テスト
+│   └── mcp-test.yml          # MCPサーバーテスト
 ├── docs/                     # ドキュメント
 │   ├── textlint-setup.md     # textlintセットアップガイド
-│   └── mcp-setup.md          # MCPサーバーセットアップガイド
+│   ├── mcp-setup.md          # MCPサーバーセットアップガイド
+│   └── github-bot-slack-notification.md # GitHub Bot Slack通知ガイド
 ├── scripts/
 │   ├── claude-slack-notification.sh  # Slack通知スクリプト
 │   ├── textlint-check.sh     # AI文章チェックスクリプト
@@ -114,6 +120,37 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | `SLACK_NOTIFICATION_DEBUG` | デバッグモード | `0` (無効) |
 | `SLACK_NOTIFICATION_IGNORE_TASK_COMPLETION` | タスク完了通知を無視 | `0` (無効) |
 | `SLACK_NOTIFICATION_MAX_LOG_SIZE` | ログファイルの最大サイズ（バイト） | `10485760` (10MB) |
+
+## GitHub Bot Slack通知機能
+
+このプロジェクトには、CodeRabbitやClaude Code ActionなどのボットがGitHubでコメントした際に、自動的にSlackに通知を送信するGitHub Actionsワークフローが含まれています。
+
+### 利用可能なワークフロー
+
+1. **基本版** (`bot-comment-notify.yml`)
+   - シンプルな実装でCodeRabbitとClaude Code Actionのコメントを検知
+   - ボットタイプに応じたアイコンと色分け
+   - コメントプレビュー機能
+
+2. **高度版** (`bot-comment-notify-advanced.yml`)
+   - キーワードベースのフィルタリング
+   - コメント重要度の自動判定
+   - チャンネル自動振り分け
+   - カスタマイズ可能な通知設定
+
+### セットアップ
+
+1. GitHub Secretsに`SLACK_WEBHOOK_URL`を設定（既存のものを使用可能）
+2. 必要に応じてワークフローファイル内の環境変数を調整
+
+### 主な機能
+
+- **ボット自動検出**: CodeRabbit、Claude Code Action、その他のGitHub Actionsボットを識別
+- **リアルタイム通知**: PRやIssueへのコメント時に即座にSlack通知
+- **フィルタリング**: キーワードベースで必要な通知のみを送信
+- **重要度判定**: エラー、セキュリティ問題などを自動的に高重要度として扱い
+
+詳細な設定方法とカスタマイズオプションについては、[docs/github-bot-slack-notification.md](docs/github-bot-slack-notification.md) を参照してください。
 
 ## textlint AI文章検出機能
 

--- a/docs/github-bot-slack-notification.md
+++ b/docs/github-bot-slack-notification.md
@@ -1,0 +1,189 @@
+# GitHub Bot Comment Slack通知ガイド
+
+## 概要
+
+このドキュメントでは、CodeRabbitやClaude Code ActionなどのボットがGitHub上でコメントした際に、自動的にSlackに通知を送信する仕組みについて説明します。
+
+## 利用可能なワークフロー
+
+### 1. 基本版 (`bot-comment-notify.yml`)
+
+シンプルな実装で、CodeRabbitとClaude Code Actionのコメントを検知してSlackに通知します。
+
+**特徴：**
+
+- CodeRabbitとGitHub Actionsボットのコメントを自動検知
+- ボットタイプに応じたアイコンと色分け
+- コメントの最初の500文字をプレビュー表示
+
+### 2. 高度版 (`bot-comment-notify-advanced.yml`)
+
+より柔軟な設定が可能な実装で、キーワードフィルタリングや重要度判定などの機能を含みます。
+
+**特徴：**
+
+- 環境変数による通知設定のカスタマイズ
+- キーワードベースのフィルタリング
+- コメント内容に基づく重要度判定
+- チャンネル自動振り分け
+- メンション機能（重要なコメントの場合）
+
+## セットアップ手順
+
+### 1. Slack Webhook URLの設定
+
+既存のSlack Webhook URLを使用するか、新規に作成します。
+
+```bash
+# 既存のWebhook URLがある場合は、それをGitHub Secretsに追加
+# GitHubリポジトリ > Settings > Secrets and variables > Actions
+# "New repository secret"から SLACK_WEBHOOK_URL を追加
+```
+
+### 2. ワークフローファイルの選択
+
+用途に応じて、以下のいずれかのワークフローを使用します。
+
+- 基本的な通知のみ必要な場合 - `bot-comment-notify.yml`
+- 高度なフィルタリングが必要な場合 - `bot-comment-notify-advanced.yml`
+
+### 3. ワークフローの有効化
+
+選択したワークフローファイルを `.github/workflows/` ディレクトリに配置すると、自動的に有効になります。
+
+## 基本版の使い方
+
+### 動作条件
+
+- PRまたはIssueへのコメント作成時
+- コメント投稿者が以下のいずれか：
+  - CodeRabbit（`coderabbitai`を含むユーザー名）
+  - GitHub Actions bot（Claude Code Action含む）
+
+### 通知内容
+
+- ボットの種類（CodeRabbit/Claude Code Action）
+- リポジトリ名
+- PR/Issue番号とタイトル
+- コメントのプレビュー（最初の500文字）
+- コメントへの直接リンク
+
+## 高度版の使い方
+
+### 環境変数による設定
+
+ワークフローファイル内の`env`セクションで以下の設定が可能：
+
+```yaml
+env:
+  # 通知するキーワード（カンマ区切り）
+  NOTIFY_KEYWORDS: "review,approved,changes requested,vulnerability,error,warning,bug,security"
+  
+  # 無視するキーワード（カンマ区切り）
+  IGNORE_KEYWORDS: "WIP,draft,test"
+  
+  # ボット別の通知設定
+  NOTIFY_CODERABBIT: "true"
+  NOTIFY_CLAUDE: "true"
+  NOTIFY_OTHER_BOTS: "false"
+```
+
+### 重要度判定
+
+コメント内容に基づいて自動的に重要度を判定：
+
+- 高重要度 - error, failed, bug, vulnerability, security
+- 成功 - approved, lgtm, success, passed
+- 警告 - warning, suggestion, consider
+- 通常 - その他
+
+高重要度のコメントには`@channel`メンションが自動的に追加されます。
+
+### チャンネル振り分け
+
+以下の条件でSlackチャンネルが自動選択されます。
+
+- mainブランチへのPR: `#production-alerts`
+- `urgent`ラベル付き: `#urgent-notifications`
+- `security`ラベル付き: `#security-alerts`
+- デフォルト: `#github-notifications`
+
+## ボット判定ロジック
+
+### CodeRabbitの判定
+
+ユーザー名に`coderabbit`が含まれる場合、CodeRabbitとして判定されます。
+
+### Claude Code Actionの判定
+
+1. ユーザー名が`github-actions[bot]`
+2. かつ、コメント内容に以下のいずれかが含まれる：
+   - Claude
+   - Anthropic
+   - claude-code-action
+   - Claude Code
+
+## カスタマイズ
+
+### 通知フォーマットの変更
+
+Slackペイロードの`blocks`セクションを編集することで、通知の見た目をカスタマイズできます。
+
+### 新しいボットの追加
+
+`Determine bot type`ステップに新しい条件を追加：
+
+```yaml
+elif [[ "${{ github.event.comment.user.login }}" =~ "your-bot-name" ]]; then
+  echo "bot_name=Your Bot Name" >> $GITHUB_OUTPUT
+  echo "bot_icon=🤖" >> $GITHUB_OUTPUT
+  echo "bot_color=#YOUR_COLOR" >> $GITHUB_OUTPUT
+```
+
+### フィルタリング条件の追加
+
+`Check if should notify`ステップにカスタム条件を追加できます。
+
+## トラブルシューティング
+
+### 通知が届かない場合
+
+1. **GitHub Secretsの確認**
+
+   ```bash
+   # ワークフローログでSecretが設定されているか確認
+   # Settings > Actions > 該当のワークフロー実行 > ログを確認
+   ```
+
+2. **ボット判定の確認**
+   - コメント投稿者のユーザー名を確認
+   - Claude Code Actionの場合、コメント内容にキーワードが含まれているか確認
+
+3. **Webhook URLのテスト**
+
+   ```bash
+   curl -X POST -H 'Content-type: application/json' \
+     --data '{"text":"Test from GitHub Actions"}' \
+     YOUR_WEBHOOK_URL
+   ```
+
+### 特定のコメントだけ通知したい場合
+
+高度版を使用し、`NOTIFY_KEYWORDS`環境変数に必要なキーワードのみを設定します。
+
+### 通知が多すぎる場合
+
+- `IGNORE_KEYWORDS`に除外したいキーワードを追加
+- 特定のボットの通知を無効化（例: `NOTIFY_OTHER_BOTS: "false"`）
+
+## セキュリティ考慮事項
+
+- Webhook URLは必ずGitHub Secretsで管理
+- ワークフローファイルにWebhook URLを直接記載しない
+- 定期的にWebhook URLをローテーション（推奨: 90日ごと）
+
+## 関連ファイル
+
+- `.github/workflows/bot-comment-notify.yml` - 基本的な通知ワークフロー
+- `.github/workflows/bot-comment-notify-advanced.yml` - 高度な通知ワークフロー
+- `scripts/claude-slack-notification.sh` - ローカルClaude Code用のSlack通知スクリプト


### PR DESCRIPTION
CodeRabbitやClaude Code ActionなどのボットがGitHubでコメントした際に 自動的にSlackに通知を送信するGitHub Actionsワークフローを追加

- 基本版と高度版の2つのワークフローを実装
- ボットタイプの自動検出（CodeRabbit、Claude Code Action）
- キーワードフィルタリングと重要度判定機能
- 日本語での通知メッセージ
- 詳細なドキュメントを追加

🤖 Generated with [Claude Code](https://claude.ai/code)