### PR TITLE
feat: Slack通知をBot Token方式に移行し複数チャンネル対応

### DIFF
--- a/.github/workflows/bot-comment-notify-advanced.yml
+++ b/.github/workflows/bot-comment-notify-advanced.yml
@@ -186,12 +186,22 @@ jobs:
           # ブランチやラベルに基づいてチャンネルを決定
           # Bot Token方式ではチャンネルIDを使用（環境変数で管理することを推奨）
           # デフォルトチャンネルID（例: C1234567890）
-          CHANNEL="${SLACK_CHANNEL_GITHUB_NOTIFICATIONS:-C1234567890}"
+          CHANNEL="${{ vars.SLACK_CHANNEL_GITHUB_NOTIFICATIONS || 'C1234567890' }}"
 
-          # PRの場合、ベースブランチをjqで取得
+          # PRの場合、GitHub APIを使用してベースブランチを取得
           if [[ -n "${{ github.event.issue.pull_request.url || '' }}" ]]; then
-            # GITHUB_EVENT_PATHからベースブランチ情報を取得
-            BASE_REF=$(jq -r '.issue.pull_request.base.ref // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+            PR_URL="${{ github.event.issue.pull_request.url }}"
+            echo "Fetching PR details from: $PR_URL"
+
+            # GitHub APIでPR情報を取得
+            PR_DATA=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
+                           -H "Accept: application/vnd.github.v3+json" \
+                           "$PR_URL")
+
+            # ベースブランチを抽出
+            BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref // empty')
+            echo "Base branch: $BASE_REF"
+
             if [[ "$BASE_REF" == "main" ]]; then
               CHANNEL="${{ vars.SLACK_CHANNEL_PRODUCTION_ALERTS || 'C0987654321' }}"
             fi

--- a/.github/workflows/bot-comment-notify-advanced.yml
+++ b/.github/workflows/bot-comment-notify-advanced.yml
@@ -184,35 +184,79 @@ jobs:
         run: |
           set -euo pipefail
           # ブランチやラベルに基づいてチャンネルを決定
-          # Bot Token方式ではチャンネルIDを使用（環境変数で管理することを推奨）
-          # デフォルトチャンネルID（例: C1234567890）
-          CHANNEL="${{ vars.SLACK_CHANNEL_GITHUB_NOTIFICATIONS || 'C1234567890' }}"
+          # Bot Token方式ではチャンネルIDを使用（GitHub Variablesで管理）
+          CHANNEL="${{ vars.SLACK_CHANNEL_GITHUB_NOTIFICATIONS }}"
+
+          # チャンネルIDの検証
+          if [[ -z "$CHANNEL" ]]; then
+            echo "❌ エラー: SLACK_CHANNEL_GITHUB_NOTIFICATIONS が設定されていません"
+            echo "📋 GitHub Variables で以下を設定してください:"
+            echo "  - SLACK_CHANNEL_GITHUB_NOTIFICATIONS (通常の通知用)"
+            echo "  - SLACK_CHANNEL_PRODUCTION_ALERTS (本番環境向け通知用、オプション)"
+            exit 1
+          fi
 
           # PRの場合、GitHub APIを使用してベースブランチを取得
           if [[ -n "${{ github.event.issue.pull_request.url || '' }}" ]]; then
             PR_URL="${{ github.event.issue.pull_request.url }}"
             echo "Fetching PR details from: $PR_URL"
 
-            # GitHub APIでPR情報を取得
-            PR_DATA=$(curl -s -H "Authorization: Bearer ${{ github.token }}" \
-                           -H "Accept: application/vnd.github.v3+json" \
-                           "$PR_URL")
+            # GitHub APIでPR情報を取得（エラーハンドリング付き）
+            if ! PR_DATA=$(curl -s -w "%{http_code}" -H "Authorization: Bearer ${{ github.token }}" \
+                                -H "Accept: application/vnd.github.v3+json" \
+                                "$PR_URL"); then
+              echo "❌ GitHub API呼び出しに失敗しました"
+              echo "⚠️  デフォルトチャンネルを使用します"
+            else
+              HTTP_CODE="${PR_DATA: -3}"
+              PR_DATA="${PR_DATA%???}"
 
-            # ベースブランチを抽出
-            BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref // empty')
-            echo "Base branch: $BASE_REF"
+              if [[ "$HTTP_CODE" != "200" ]]; then
+                echo "❌ GitHub API エラー (HTTP $HTTP_CODE)"
+                echo "⚠️  デフォルトチャンネルを使用します"
+              else
+                # ベースブランチを抽出（jqエラーハンドリング付き）
+                if BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref // empty' 2>/dev/null) && [[ -n "$BASE_REF" ]]; then
+                  echo "✅ Base branch detected: $BASE_REF"
+                else
+                  echo "⚠️  ベースブランチの取得に失敗、デフォルトチャンネルを使用"
+                  BASE_REF=""
+                fi
+              fi
+            fi
 
             if [[ "$BASE_REF" == "main" ]]; then
-              CHANNEL="${{ vars.SLACK_CHANNEL_PRODUCTION_ALERTS || 'C0987654321' }}"
+              PROD_CHANNEL="${{ vars.SLACK_CHANNEL_PRODUCTION_ALERTS }}"
+              if [[ -n "$PROD_CHANNEL" ]]; then
+                CHANNEL="$PROD_CHANNEL"
+                echo "📢 Production alert channel selected: $CHANNEL"
+              else
+                echo "⚠️  警告: SLACK_CHANNEL_PRODUCTION_ALERTS が未設定のため、デフォルトチャンネルを使用"
+              fi
             fi
           fi
 
           # ラベルの確認（jqを使用）
           LABELS=$(jq -r '.issue.labels[]?.name // empty' "$GITHUB_EVENT_PATH" 2>/dev/null | tr '\n' ' ' || echo "")
+          echo "Labels detected: $LABELS"
+
+          # ラベルベースのチャンネル振り分け
           if [[ "$LABELS" =~ "urgent" ]]; then
-            CHANNEL="${{ vars.SLACK_CHANNEL_URGENT_NOTIFICATIONS || 'C1122334455' }}"
+            URGENT_CHANNEL="${{ vars.SLACK_CHANNEL_URGENT_NOTIFICATIONS }}"
+            if [[ -n "$URGENT_CHANNEL" ]]; then
+              CHANNEL="$URGENT_CHANNEL"
+              echo "🚨 Urgent channel selected: $CHANNEL"
+            else
+              echo "⚠️  SLACK_CHANNEL_URGENT_NOTIFICATIONS が未設定のため、デフォルトチャンネルを使用"
+            fi
           elif [[ "$LABELS" =~ "security" ]]; then
-            CHANNEL="${{ vars.SLACK_CHANNEL_SECURITY_ALERTS || 'C5566778899' }}"
+            SECURITY_CHANNEL="${{ vars.SLACK_CHANNEL_SECURITY_ALERTS }}"
+            if [[ -n "$SECURITY_CHANNEL" ]]; then
+              CHANNEL="$SECURITY_CHANNEL"
+              echo "🔒 Security channel selected: $CHANNEL"
+            else
+              echo "⚠️  SLACK_CHANNEL_SECURITY_ALERTS が未設定のため、デフォルトチャンネルを使用"
+            fi
           fi
 
           echo "channel=$CHANNEL" >> $GITHUB_OUTPUT

--- a/.github/workflows/bot-comment-notify-advanced.yml
+++ b/.github/workflows/bot-comment-notify-advanced.yml
@@ -1,5 +1,11 @@
 name: Advanced Bot Comment Notification
 
+# このワークフローはSlack Bot Tokenを使用して複数チャンネルへの通知を実現します
+# 必要なセットアップ:
+# 1. Slack Appを作成し、chat:write, chat:write.publicスコープを付与
+# 2. Bot User OAuth TokenをGitHub Secretsに SLACK_BOT_TOKEN として保存
+# 3. チャンネルIDを確認（例: C1234567890）
+
 on:
   issue_comment:
     types: [created]
@@ -178,24 +184,25 @@ jobs:
         run: |
           set -euo pipefail
           # ブランチやラベルに基づいてチャンネルを決定
-          # デフォルトチャンネル
-          CHANNEL="#github-notifications"
+          # Bot Token方式ではチャンネルIDを使用（環境変数で管理することを推奨）
+          # デフォルトチャンネルID（例: C1234567890）
+          CHANNEL="${SLACK_CHANNEL_GITHUB_NOTIFICATIONS:-C1234567890}"
 
           # PRの場合、ベースブランチをjqで取得
           if [[ -n "${{ github.event.issue.pull_request.url || '' }}" ]]; then
             # GITHUB_EVENT_PATHからベースブランチ情報を取得
             BASE_REF=$(jq -r '.issue.pull_request.base.ref // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
             if [[ "$BASE_REF" == "main" ]]; then
-              CHANNEL="#production-alerts"
+              CHANNEL="${{ vars.SLACK_CHANNEL_PRODUCTION_ALERTS || 'C0987654321' }}"
             fi
           fi
 
           # ラベルの確認（jqを使用）
           LABELS=$(jq -r '.issue.labels[]?.name // empty' "$GITHUB_EVENT_PATH" 2>/dev/null | tr '\n' ' ' || echo "")
           if [[ "$LABELS" =~ "urgent" ]]; then
-            CHANNEL="#urgent-notifications"
+            CHANNEL="${{ vars.SLACK_CHANNEL_URGENT_NOTIFICATIONS || 'C1122334455' }}"
           elif [[ "$LABELS" =~ "security" ]]; then
-            CHANNEL="#security-alerts"
+            CHANNEL="${{ vars.SLACK_CHANNEL_SECURITY_ALERTS || 'C5566778899' }}"
           fi
 
           echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
@@ -204,8 +211,8 @@ jobs:
         if: steps.should-notify.outputs.should_notify == 'true'
         uses: slackapi/slack-github-action@v1.26.0
         with:
-          # channel-idパラメータでチャンネルを指定可能（オプション）
-          # channel-id: ${{ steps.slack-channel.outputs.channel }}
+          # Bot Token方式でチャンネルを動的に指定
+          channel-id: ${{ steps.slack-channel.outputs.channel }}
           payload: |
             {
               "text": "${{ steps.comment-analysis.outputs.importance_icon }} ${{ steps.bot-info.outputs.bot_icon }} ${{ steps.bot-info.outputs.bot_name }} commented on ${{ github.event.issue.pull_request && 'PR' || 'Issue' }} #${{ github.event.issue.number }} ${{ steps.comment-analysis.outputs.mention }}",
@@ -302,11 +309,11 @@ jobs:
               "attachments": [
                 {
                   "color": "${{ steps.bot-info.outputs.bot_color }}",
-                  "footer": "GitHub Bot Comment Notifier | ${{ steps.slack-channel.outputs.channel }}",
+                  "footer": "GitHub Bot Comment Notifier",
                   "footer_icon": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
                   "ts": "${{ github.event.comment.created_at }}"
                 }
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/bot-comment-notify.yml
+++ b/.github/workflows/bot-comment-notify.yml
@@ -1,5 +1,11 @@
 name: Bot Comment Notification
 
+# このワークフローはSlack Bot Tokenを使用して通知を送信します
+# Webhook URLバージョンから移行する場合:
+# 1. Slack Appを作成し、chat:write, chat:write.publicスコープを付与
+# 2. Bot User OAuth TokenをGitHub Secretsに SLACK_BOT_TOKEN として保存
+# 3. 環境変数でチャンネルIDを設定（SLACK_CHANNEL_ID）
+
 on:
   issue_comment:
     types: [created]
@@ -8,6 +14,10 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+
+env:
+  # デフォルトのSlackチャンネルID（環境変数またはGitHub Variables で上書き可能）
+  SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID || 'C1234567890' }}
 
 jobs:
   notify-slack:
@@ -67,6 +77,7 @@ jobs:
       - name: Send Slack notification
         uses: slackapi/slack-github-action@v1.26.0
         with:
+          channel-id: ${{ env.SLACK_CHANNEL_ID }}
           payload: |
             {
               "text": "${{ steps.bot-type.outputs.bot_icon }} ${{ steps.bot-type.outputs.bot_name }} commented on ${{ github.event.issue.pull_request && 'PR' || 'Issue' }} #${{ github.event.issue.number }}",
@@ -150,4 +161,4 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/bot-comment-notify.yml
+++ b/.github/workflows/bot-comment-notify.yml
@@ -16,8 +16,10 @@ permissions:
   pull-requests: read
 
 env:
-  # デフォルトのSlackチャンネルID（環境変数またはGitHub Variables で上書き可能）
-  SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID || 'C1234567890' }}
+  # SlackチャンネルID（GitHub Variablesでの設定が必須）
+  # セットアップ手順: Settings > Secrets and variables > Actions > Variables タブ
+  # SLACK_CHANNEL_ID を実際のチャンネルIDに設定してください
+  SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
 
 jobs:
   notify-slack:
@@ -29,6 +31,20 @@ jobs:
        github.event.comment.user.login == 'github-actions[bot]')
 
     steps:
+      - name: Validate Slack configuration
+        run: |
+          set -euo pipefail
+          if [[ -z "${{ env.SLACK_CHANNEL_ID }}" ]]; then
+            echo "❌ エラー: SLACK_CHANNEL_ID が設定されていません"
+            echo "📋 セットアップ手順:"
+            echo "1. GitHub リポジトリの Settings > Secrets and variables > Actions に移動"
+            echo "2. Variables タブで 'New repository variable' をクリック"
+            echo "3. Name: SLACK_CHANNEL_ID, Value: 実際のSlackチャンネルID を入力"
+            echo "4. 詳細は docs/github-bot-slack-notification.md を参照"
+            exit 1
+          fi
+          echo "✅ Slack設定確認完了: チャンネルID = ${{ env.SLACK_CHANNEL_ID }}"
+
       - name: Determine bot type
         id: bot-type
         env:

--- a/docs/slack-app-setup.md
+++ b/docs/slack-app-setup.md
@@ -1,0 +1,168 @@
+# Slack App設定ガイド（GitHub Actions連携用）
+
+このガイドでは、GitHub ActionsからSlackに通知を送信するためのSlack Appの設定方法を詳しく説明します。
+
+## 概要
+
+Slack Webhook URLの制限を回避し、複数チャンネルへの動的な通知を実現するために、Slack Appを使用したBot Token方式を推奨します。
+
+### Webhook URL vs Bot Tokenの比較
+
+| 機能 | Webhook URL | Bot Token |
+|------|-------------|-----------|
+| 送信先チャンネル数 | 1つのみ | 複数可能 |
+| チャンネルの動的指定 | 不可 | 可能 |
+| プライベートチャンネル | 設定時に指定したチャンネルのみ | 招待されたチャンネル全て |
+| セットアップの簡易さ | 簡単 | やや複雑 |
+| 権限管理 | 固定 | 柔軟に設定可能 |
+
+## Slack App作成手順
+
+### 1. Slack Appの作成
+
+1. [api.slack.com/apps](https://api.slack.com/apps) にアクセス
+2. 右上の「Create New App」をクリック
+3. 「From scratch」を選択
+4. アプリ情報を入力：
+   - **App Name**: `GitHub Actions Bot` （任意の名前）
+   - **Pick a workspace**: 通知を送信したいワークスペースを選択
+5. 「Create App」をクリック
+
+### 2. Bot Userの設定
+
+1. 左側メニューから「App Home」を選択
+2. 「Your App's Presence in Slack」セクションで以下を設定：
+   - **Always Show My Bot as Online**: オン（推奨）
+3. 「Bot User」セクションがない場合は、「Review Scopes to Add」をクリック
+
+### 3. OAuth & Permissionsの設定
+
+1. 左側メニューから「OAuth & Permissions」を選択
+2. 「Scopes」セクションまでスクロール
+3. 「Bot Token Scopes」で「Add an OAuth Scope」をクリック
+4. 以下のスコープを追加：
+   - `chat:write` - 基本的なメッセージ送信権限
+   - `chat:write.public` - パブリックチャンネルへの送信権限（ボットが参加していないチャンネルでも送信可能）
+   - `chat:write.customize` - ユーザー名とアイコンのカスタマイズ（オプション）
+
+### 4. アプリのインストール
+
+1. ページ上部の「Install to Workspace」をクリック
+2. 権限の確認画面で内容を確認
+3. 「許可する」をクリック
+4. インストール完了後、「Bot User OAuth Token」が表示される
+5. `xoxb-`で始まるトークンをコピー（後で使用）
+
+### 5. Bot Tokenの保存
+
+#### GitHub Secretsへの登録
+
+1. GitHubリポジトリにアクセス
+2. Settings → Secrets and variables → Actions
+3. 「New repository secret」をクリック
+4. 以下を入力：
+   - **Name**: `SLACK_BOT_TOKEN`
+   - **Secret**: コピーしたBot Token（xoxb-で始まる文字列）
+5. 「Add secret」をクリック
+
+## チャンネルIDの確認方法
+
+Bot Token方式では、チャンネル名ではなくチャンネルIDを使用する必要があります。
+
+### デスクトップアプリまたはWebアプリでの確認
+
+1. Slackでチャンネルを開く
+2. チャンネル名を右クリック
+3. 「チャンネル詳細を表示」または「View channel details」を選択
+4. ポップアップの最下部にある「チャンネルID」をコピー
+
+### モバイルアプリでの確認
+
+1. チャンネルを開く
+2. 上部のチャンネル名をタップ
+3. 「設定」または歯車アイコンをタップ
+4. 下にスクロールして「チャンネルID」を確認
+
+### APIでの確認
+
+```bash
+# Slack APIを使用してチャンネル一覧を取得
+curl -H "Authorization: Bearer xoxb-your-token" \
+  https://slack.com/api/conversations.list?types=public_channel,private_channel
+```
+
+## GitHub Variablesの設定
+
+チャンネルIDはハードコードせず、GitHub Variablesで管理することを推奨します。
+
+### Repository Variablesの設定
+
+1. GitHubリポジトリ → Settings → Secrets and variables → Actions
+2. 「Variables」タブを選択
+3. 「New repository variable」をクリック
+4. 以下のような変数を追加：
+
+```
+SLACK_CHANNEL_ID=C1234567890
+SLACK_CHANNEL_GITHUB_NOTIFICATIONS=C1234567890
+SLACK_CHANNEL_PRODUCTION_ALERTS=C0987654321
+SLACK_CHANNEL_URGENT_NOTIFICATIONS=C1122334455
+SLACK_CHANNEL_SECURITY_ALERTS=C5566778899
+```
+
+### Organization Variablesの設定（組織全体で使用する場合）
+
+1. GitHub Organization → Settings → Secrets and variables → Actions
+2. 同様の手順で変数を追加
+
+## プライベートチャンネルへの送信
+
+プライベートチャンネルに送信する場合は、以下の手順が必要です：
+
+1. 対象のプライベートチャンネルにアプリを招待
+   - チャンネルで `/invite @GitHub Actions Bot` を実行
+   - またはチャンネル設定から「インテグレーション」→「アプリを追加」
+
+2. チャンネルIDを確認して使用
+
+## トラブルシューティング
+
+### 「channel_not_found」エラー
+
+- チャンネルIDが正しいか確認（チャンネル名ではなくID）
+- プライベートチャンネルの場合、ボットが招待されているか確認
+- `chat:write.public`スコープが付与されているか確認
+
+### 「not_authed」エラー
+
+- Bot Tokenが正しく設定されているか確認
+- トークンが`xoxb-`で始まっているか確認
+- GitHub Secretsの名前が正しいか確認
+
+### 「missing_scope」エラー
+
+- 必要なスコープが付与されているか確認
+- アプリを再インストールして権限を更新
+
+## セキュリティのベストプラクティス
+
+1. **Bot Tokenの管理**
+   - 絶対にコードにハードコードしない
+   - GitHub Secretsで安全に管理
+   - 定期的にトークンをローテーション（90日ごと推奨）
+
+2. **最小権限の原則**
+   - 必要最小限のスコープのみを付与
+   - 不要になったスコープは削除
+
+3. **チャンネルアクセスの制限**
+   - センシティブな情報を扱うチャンネルへのアクセスは慎重に
+
+4. **監査ログの確認**
+   - Slack管理画面で定期的にアプリのアクティビティを確認
+
+## 参考リンク
+
+- [Slack API Documentation](https://api.slack.com/)
+- [GitHub Actions: Encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+- [slackapi/slack-github-action](https://github.com/slackapi/slack-github-action)

--- a/docs/slack-app-setup.md
+++ b/docs/slack-app-setup.md
@@ -87,7 +87,7 @@ Bot Token方式では、チャンネル名ではなくチャンネルIDを使用
 
 ```bash
 # Slack APIを使用してチャンネル一覧を取得
-curl -H "Authorization: Bearer xoxb-your-token" \
+curl -H "Authorization: Bearer <YOUR_SLACK_BOT_TOKEN>" \
   https://slack.com/api/conversations.list?types=public_channel,private_channel
 ```
 


### PR DESCRIPTION
- Webhook URLの単一チャンネル制限を解決
- Bot Token方式により動的なチャンネル指定が可能に
- GitHub Variablesでチャンネル管理を実装
- 詳細なSlack App設定ガイドを追加

🤖 Generated with [Claude Code](https://claude.ai/code)